### PR TITLE
Update README to an up-to-date, more detailed version and fix several issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,27 @@ Our paper's link is [Med-MoE: Mixture of Domain-Specific Experts for Lightweight
 
 **Prepare the Environment**
 
-1. Clone and navigate to the TinyMed project directory:
+1. Clone and navigate to the Med-MoE project directory:
    ```bash
-   cd TinyMed
+   cd Med-MoE
    ```
 
 2. Set up your environment:
+  
+CUDA 12.4 is recommended. However, you can use another version as long as you update the corresponding package versions in your pymroject.poml file and adjust the PyTorch download lines accordingly.
    ```bash
-   conda create -n tinymed python=3.10 -y
-   conda activate tinymed
+   conda create -n Med-MoE python=3.10 -y
+   conda activate Med-MoE
    pip install --upgrade pip
    pip install -e .
    pip install -e ".[train]"
+   pip3 install torch torchvision torchaudio
    pip install flash-attn --no-build-isolation
    ```
 
-3. Replace the default MoE with our provided version.
+3. Please download the domain-specific router provided by us or trained by yourself, and replace its path in the `moellava/model/language_model/llava_stablelm_moe.py` file.
 
-4. Please download the domain-specific router provided by us or trained by yourself, and replace its path in the `moellava/model/language_model/llava_stablelm_moe.py` file.
+4. Download the corresponding Clip, Phi2, and Stablelm models into the current folder.
 
 ## Training
 
@@ -42,6 +45,42 @@ Our paper's link is [Med-MoE: Mixture of Domain-Specific Experts for Lightweight
    - **For MoE-Tuning Stage**: [Training Jsonl](https://drive.google.com/file/d/1mf3lyW7CbfCowGC58gXsam-3dPwIenbJ/view?usp=sharing)
    - **MoE-Tuning Stage Image Data**: Note that some images from LLaVA-Med are no longer available; these have been excluded from training. [Stage3 ImageData](https://drive.google.com/file/d/1l9hnxa2Y3D8rhNLldtCQ0vGPhsiWH_Su/view?usp=sharing)
    -**Test.json for VQA**:https://drive.google.com/file/d/1pyGsm8G0Gig63DAnOdLuUn3IyxrztWtR/view?usp=sharing
+  
+The data can be organized as shown below. You can modify it by editing [download_images.py](./download_images.py), but be sure to update the corresponding content in the scripts and elsewhere accordingly: 
+
+```
+Med-MoE
+├── moe
+├── moellava
+├── data
+│   ├── 3vqa
+│   │   ├── images
+│   │   │   ├── data_RAD
+│   │   │   ├── pvqa
+│   │   │   └── slake
+│   │   ├── test_pvqa.json
+│   │   ├── test_slake.json
+│   │   ├── test_rad.json
+│   │   └── train_all.json
+│   ├── alignment
+│   │   └── llava_med_alignment_500k_filter.json
+│   ├── images
+│   ├── instruct
+│   ├── pmc_articles
+│   └── llava_med_image_urls.jsonl
+│
+...
+```
+
+## Train
+
+Sequently run the scripts in `scripts/train_scripts`. The following one is an example for `Phi2`:
+
+```
+bash scripts/train_scripts/phi2/pretrain.sh
+bash scripts/train_scripts/phi2/finetune.sh
+bash scripts/train_scripts/phi2/finetune_moe_allvqa.sh
+```
      
 ## Web Launch
 
@@ -81,38 +120,9 @@ Our paper's link is [Med-MoE: Mixture of Domain-Specific Experts for Lightweight
 
 ## Evaluation
 
-The evaluation process involves running the model on multiple GPUs and combining the results. Below are the detailed steps and commands:
+The evaluation process involves running the model on multiple GPUs and combining the results. Modify [eval.sh](./eval.sh) accordingly and execute it with bash.
 
-```bash
-# Set the number of chunks and GPUs
-CHUNKS=2
-GPUS=(0 1)
 
-# Run inference on each GPU
-for IDX in {0..1}; do
-    GPU_IDX=${GPUS[$IDX]}
-    PORT=$((${GPUS[$IDX]} + 29500))
-    MASTER_PORT_ENV="MASTER_PORT=$PORT"
-    deepspeed --include localhost:$GPU_IDX --master_port $PORT model_vqa_med.py \
-        --model-path your_model_path \
-        --question-file ./test_rad.json \
-        --image-folder ./3vqa/images \
-        --answers-file ./test_llava-13b-chunk${CHUNKS}_${IDX}.jsonl \
-        --temperature 0 \
-        --num-chunks $CHUNKS \
-        --chunk-idx $IDX \
-        --conv-mode stablelm/phi2 &
-done
-
-# Combine JSONL results into one file
-cat ./test_llava-13b-chunk2_{0..1}.jsonl > ./radvqa.jsonl
-
-# Run evaluation
-python run_eval.py \
-    --gt ./3vqa/test_rad.json \
-    --pred ./radvqa.jsonl \
-    --output ./data_RAD/wrong_answers.json
-```
 
 ## Acknowledgements
 

--- a/download_images.py
+++ b/download_images.py
@@ -12,9 +12,9 @@ import urllib.request
 from tqdm import tqdm
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--input_path', type=str, default='./llava_med_image_urls.jsonl')
-parser.add_argument('--pmc_output_path', type=str, default='/data/pmc_articles/')
-parser.add_argument('--images_output_path', type=str, default='/data/images/')
+parser.add_argument('--input_path', type=str, default='./data/llava_med_image_urls.jsonl')
+parser.add_argument('--pmc_output_path', type=str, default='./data/pmc_articles/')
+parser.add_argument('--images_output_path', type=str, default='./data/images/')
 parser.add_argument('--remove_pmc', action='store_true', default=True, help='remove pmc articles after image extraction')
 parser.add_argument('--cpus', type=int, default=-1, help='number of cpus to use in multiprocessing (default: all)')
 args = parser.parse_args()

--- a/eval.sh
+++ b/eval.sh
@@ -1,0 +1,33 @@
+# Set the number of chunks and GPUs
+CHUNKS=2
+GPUS=(0 1)
+VT_VERSION=./clip-vit-large-patch14-336
+
+# Run inference on each GPU
+for IDX in {0..1}; do
+    GPU_IDX=${GPUS[$IDX]}
+    PORT=$((${GPUS[$IDX]} + 29500))
+    MASTER_PORT_ENV="MASTER_PORT=$PORT"
+    deepspeed --include localhost:$GPU_IDX --master_port $PORT model_vqa_med.py \
+        --model-path your_model_path \
+        --question-file ./data/3vqa/test_rad.json \
+        --image-folder ./data/3vqa/images \
+        --answers-file ./test_llava-13b-chunk${CHUNKS}_${IDX}.jsonl \
+        --image_tower $VT_VERSION \
+        --temperature 0 \
+        --num-chunks $CHUNKS \
+        --chunk-idx $IDX \
+        --conv-mode phi &
+        # --conv-mode stablelm &
+done
+
+wait
+
+# Combine JSONL results into one file
+cat ./test_llava-13b-chunk2_{0..1}.jsonl > ./radvqa.jsonl
+
+# Run evaluation
+python run_eval.py \
+    --gt ./data/3vqa/test_rad.json \
+    --pred ./radvqa.jsonl \
+    --output ./wrong_answers.json

--- a/model_vqa_med.py
+++ b/model_vqa_med.py
@@ -11,7 +11,7 @@ from moellava.model.builder import load_pretrained_model
 from moellava.utils import disable_torch_init
 from moellava.mm_utils import tokenizer_image_token, process_images, get_model_name_from_path
 from moellava.mm_utils import tokenizer_image_token, get_model_name_from_path, KeywordsStoppingCriteria
-
+from transformers import AutoConfig
 from PIL import Image
 import math
 # os.environ.setdefault('MASTER_ADDR', '127.0.0.1')
@@ -79,19 +79,37 @@ prompt_pool = detail_describe_instructions + concise_describe_instructions
 prompt_pool = [ "Describe the following image in detail."]
 
 
-def patch_config(config):
+# def patch_config(config):
+#     patch_dict = {
+#         "use_mm_proj": True,
+#         "mm_vision_tower": "openai/clip-vit-large-patch14",
+#         "mm_hidden_size": 1024
+#     }
+
+#     cfg = AutoConfig.from_pretrained(config)
+#     if not hasattr(cfg, "mm_vision_tower"):
+#         print(f'`mm_vision_tower` not found in `{config}`, applying patch and save to disk.')
+#         for k, v in patch_dict.items():
+#             setattr(cfg, k, v)
+#         cfg.save_pretrained(config)
+def patch_config(config, image_tower):
+    # patch_dict = {
+    #     "use_mm_proj": True,
+    #     "mm_vision_tower": image_tower,  # 使用传入的参数
+    #     "mm_hidden_size": 1024
+    # }
     patch_dict = {
         "use_mm_proj": True,
-        "mm_vision_tower": "openai/clip-vit-large-patch14",
+        "mm_image_tower": image_tower,  # 修改为 mm_image_tower
         "mm_hidden_size": 1024
     }
 
     cfg = AutoConfig.from_pretrained(config)
-    if not hasattr(cfg, "mm_vision_tower"):
-        print(f'`mm_vision_tower` not found in `{config}`, applying patch and save to disk.')
-        for k, v in patch_dict.items():
-            setattr(cfg, k, v)
-        cfg.save_pretrained(config)
+    # 这里可以选择无论如何都更新，或者只在不存在时更新
+    print(f"Applying patch: setting mm_vision_tower to {image_tower} in config {config}")
+    for k, v in patch_dict.items():
+        setattr(cfg, k, v)
+    cfg.save_pretrained(config)
 
 
 
@@ -101,6 +119,9 @@ def eval_model(args):
     # Model
     disable_torch_init()
     model_path = os.path.expanduser(args.model_path)
+    if args.image_tower:
+        patch_config(model_path, args.image_tower)
+    
     model_name = get_model_name_from_path(model_path)
     print(model_name)
     tokenizer, model, image_processor, context_len = load_pretrained_model(model_path, args.model_base, model_name)
@@ -240,6 +261,8 @@ if __name__ == "__main__":
     parser.add_argument("--max_new_tokens", type=int, default=128)
     parser.add_argument("--single-pred-prompt", action="store_true")
     parser.add_argument("--return_gating_logit", type=str, default=None)
+    parser.add_argument("--image_tower", type=str, default="openai/clip-vit-large-patch14", 
+                    help="Identifier or local path for the image tower (CLIP model)")
     args = parser.parse_args()
 
     eval_model(args)

--- a/moellava/model/language_model/llava_phi_moe.py
+++ b/moellava/model/language_model/llava_phi_moe.py
@@ -27,7 +27,9 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from ..llava_arch import LlavaMetaModel, LlavaMetaForCausalLM
 
-from deepspeed.moe.layer import MoE
+# from deepspeed.moe.layer import MoE
+# Switch to the provided MoE
+from moe.layer import MoE
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union, List
 import torch.nn as nn

--- a/moellava/model/language_model/llava_stablelm_moe.py
+++ b/moellava/model/language_model/llava_stablelm_moe.py
@@ -26,8 +26,8 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from ..llava_arch import LlavaMetaModel, LlavaMetaForCausalLM
 
-from deepspeed.moe.layer import MoE#If you replace the moe file in deepspeed 
-#Or just use "from moe.layer import MoE"
+# from deepspeed.moe.layer import MoE
+from moe.layer import MoE
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union, List
 import torch.nn as nn

--- a/moellava/model/multimodal_encoder/builder.py
+++ b/moellava/model/multimodal_encoder/builder.py
@@ -6,20 +6,23 @@ if a == '4' and int(b) >= 37:
     from .siglip_encoder import SiglipVisionTower
 # from .languagebind import LanguageBindImageTower, LanguageBindVideoTower
 
-# ============================================================================================================
-
+# ============================================================================================================    
 def build_image_tower(image_tower_cfg, **kwargs):
     image_tower = getattr(image_tower_cfg, 'mm_image_tower', getattr(image_tower_cfg, 'image_tower', None))
-    is_absolute_path_exists = os.path.exists(image_tower)
-    
-    if is_absolute_path_exists or image_tower.startswith("openai") or image_tower.startswith("laion"):
-        return CLIPVisionTower(image_tower, args=image_tower_cfg, **kwargs) 
+
+    image_tower = os.path.abspath(image_tower)
+
+    if os.path.exists(image_tower):
+        return CLIPVisionTower(image_tower, args=image_tower_cfg, **kwargs)
+    if image_tower.startswith("openai") or image_tower.startswith("laion"):
+        return CLIPVisionTower(image_tower, args=image_tower_cfg, **kwargs)
     if image_tower.startswith("google") or ('siglip' in image_tower.lower()):
         print('Using SigLip')
         return SiglipVisionTower(image_tower, image_tower_cfg, **kwargs)
     if image_tower.endswith('LanguageBind_Image'):
         return LanguageBindImageTower(image_tower, args=image_tower_cfg, cache_dir='./cache_dir', **kwargs)
     raise ValueError(f'Unknown image tower: {image_tower}')
+
 
 def build_video_tower(video_tower_cfg, **kwargs):
     video_tower = getattr(video_tower_cfg, 'mm_video_tower', getattr(video_tower_cfg, 'video_tower', None))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "torch==2.0.1", "torchvision==0.15.2",
     "transformers==4.37.0", "tokenizers==0.15.1", "sentencepiece==0.1.99", "shortuuid",
-    "accelerate==0.21.0", "peft==0.4.0", "bitsandbytes==0.41.0",
+    "accelerate==0.21.0", "peft==0.4.0", "bitsandbytes==0.45.3",
     "pydantic<2,>=1", "markdown2[all]", "numpy", "scikit-learn==1.2.2",
     "gradio==3.37.0", "gradio_client==0.7.0",
     "requests", "httpx==0.24.0", "uvicorn", "fastapi",
     "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
-    "protobuf==4.24.4", "tiktoken==0.5.2", "openai==0.28.0", "openpyxl==3.1.2"
+    "protobuf==4.24.4", "tiktoken==0.5.2", "openai==0.28.0", "openpyxl==3.1.2",
+    "tabulate", "nltk"
 ]
 
 [project.optional-dependencies]

--- a/run_eval.py
+++ b/run_eval.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import collections
 from nltk.translate.bleu_score import sentence_bleu, SmoothingFunction
-from eval_metrics.evaluate_metrics import calculate_exactmatch, calculate_f1score, bleu, calculate_appearance_with_normalization
+from moellava.eval.eval_metrics.evaluate_metrics import calculate_exactmatch, calculate_f1score, bleu, calculate_appearance_with_normalization
 from tabulate import tabulate
 
 import warnings


### PR DESCRIPTION
When I attempted to train and evaluate Med-MoE locally, I ran into several issues that took me some time to resolve. These issues can be avoided by updating certain files and the README, so I have addressed them in this PR.

I should note that after my modifications, I can at least train the Stage 1 model for a while. Unfortunately, I couldn’t train the entire model due to some unknown reasons. My server repeatedly encountered CUDA out-of-memory errors, even when I reduced the training batch size to 4. However, I’m confident it can run—at least for Stage 1. My setup is as follows:

- 8× RTX 3090 (24G)
- CUDA 12.4
- Driver 550.78

Here I provide two images to show that I can truly run this:

This image illustrates the GPU memory usage during training with bathcsize 4. By the following morning, the server became unresponsive, likely due to the excessive GPU, CPU, and I/O demands during the training process.
<img width="597" alt="23f8e663823fdbac994fc1ab53ec386" src="https://github.com/user-attachments/assets/9f5b2dd0-4fc2-4736-abd6-1894d87d220d" />

This image shows the metrics after I ran evaluation:

<img width="290" alt="b1ba040a8cf5df96121e57dced5e817" src="https://github.com/user-attachments/assets/14812ddd-306d-4898-abc2-8669b9e4aea0" />


### Summary of Modifications

1. **`pyproject.toml`**  
   - Removed lines specifying the PyTorch version.  
   - Upgraded `bitsandbytes` so it can compile under CUDA 12.4 or newer. (The original version only supported up to CUDA 12.3.)  
   - Added `tabulate` and `nltk` dependencies for `run_eval.py`.

2. **`run_eval.py`**  
   - Updated line 5 to:
     ```python
     from moellava.eval.eval_metrics.evaluate_metrics import calculate_exactmatch, calculate_f1score, bleu, calculate_appearance_with_normalization
     ```

3. **`eval.sh`**  
   - Nearly identical to the evaluation commands in the old README, but placed in a `.sh` file for convenience.

4. **`download_images.py`**  
   - Modified the output path to match the Llava-med data structure.

5. **`/moellava/model/language_model/llava_phi_moe.py`**  
   - Replaced the default MoE implementation with your provided version.

6. **`/moellava/model/language_model/llava_stablelm_moe.py`**  
   - Replaced the default MoE implementation with your provided version.

7. **`/moellava/model/multimodal_encoder/builder.py`**  
   - Modified the `build_image_tower` function to allow evaluation with a locally deployed CLIP model.

8. **`model_vqa_med.py`**  
   - Added an import statement for `AutoConfig`.  
   - Updated the `patch_config` function to enable evaluation with a locally deployed CLIP model.

9. **`README.md`**  
   - Corrected references to `TinyMed` in “Prepare the Environment,” reflecting this repository’s new name.  
   - Since I changed `pyproject.toml`, I added a PyTorch install command under “Prepare the Environment.”  
   - Included a directory tree example under “Prepare the Datasets.”  
   - Shortened the “Evaluation” section by referencing the new `eval.sh` script.

---

Thank you for reviewing these changes! If you have any questions or concerns, please let me know.